### PR TITLE
Remove duplicate **/.git entry from blocked paths

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -274,7 +274,6 @@ const defaultSettings: CSSVariablesSettings = {
     '**/.hg',
     '**/CVS',
     '**/.DS_Store',
-    '**/.git',
     '**/node_modules',
     '**/bower_components',
     '**/tmp',


### PR DESCRIPTION
This PR removes the duplicate `**/.git` entry from the blocklist.