### PR TITLE
Provide empty hostname for GoTo Definition Locations

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -119,7 +119,7 @@ const parseCSSVariablesFromText = ({
     const service = languageService();
 
     const document = TextDocument.create(
-      `file://${filePath}`,
+      `file:///${filePath}`,
       'css',
       0,
       content
@@ -149,7 +149,7 @@ const parseCSSVariablesFromText = ({
         const variable: CSSVariable = {
           symbol,
           definition: {
-            uri: `file://${filePath}`,
+            uri: `file:///${filePath}`,
             range: Range.create(
               document.positionAt(symbol.node.offset),
               document.positionAt(symbol.node.end)


### PR DESCRIPTION
I'm still experiencing the issue described by #10 on version 2.3.6 on Windows.  I believe this is because of an issue with the way the file URI is being constructed currently. As a result, Windows is not parsing the hostname properly and is failing to open the file.  

This is a pretty common problem when building file URIs.  You can see a description of it in more detail at these links:

[https://en.wikipedia.org/wiki/File_URI_scheme#How_many_slashes?](https://en.wikipedia.org/wiki/File_URI_scheme#How_many_slashes?)
https://docs.microsoft.com/en-us/archive/blogs/ie/file-uris-in-windows

This change aligns the file path creation logic with the recommended format for FileUris from the second link