### PR TITLE
Ignore .next & .cache folders, reorder alphabetically

### DIFF
--- a/.changeset/swift-dots-approve.md
+++ b/.changeset/swift-dots-approve.md
@@ -1,0 +1,5 @@
+---
+"css-variables-language-server": patch
+---
+
+Ignore .next & .cache folders, reorder alphabetically

--- a/packages/css-variables-language-server/src/CSSVariableManager.ts
+++ b/packages/css-variables-language-server/src/CSSVariableManager.ts
@@ -34,6 +34,7 @@ export interface CSSVariablesSettings {
 export const defaultSettings: CSSVariablesSettings = {
   lookupFiles: ['**/*.less', '**/*.scss', '**/*.sass', '**/*.css'],
   blacklistFolders: [
+    '**/.cache',
     '**/.DS_Store',
     '**/.git',
     '**/.hg',

--- a/packages/css-variables-language-server/src/CSSVariableManager.ts
+++ b/packages/css-variables-language-server/src/CSSVariableManager.ts
@@ -34,16 +34,17 @@ export interface CSSVariablesSettings {
 export const defaultSettings: CSSVariablesSettings = {
   lookupFiles: ['**/*.less', '**/*.scss', '**/*.sass', '**/*.css'],
   blacklistFolders: [
-    '**/.git',
-    '**/.svn',
-    '**/.hg',
-    '**/CVS',
     '**/.DS_Store',
-    '**/node_modules',
+    '**/.git',
+    '**/.hg',
+    '**/.next',
+    '**/.svn',
     '**/bower_components',
-    '**/tmp',
+    '**/CVS',
     '**/dist',
+    '**/node_modules',
     '**/tests',
+    '**/tmp',
   ],
 };
 


### PR DESCRIPTION
Hi @vunguyentuan, thanks for this extension, works well! 🙌 

Just a quick PR to:

1. Add the `.next` and `.cache` folders to the `blacklistFolders` default configuration, because these contain built files from Next.js and Gatsby
2. Reorder the entries in the `blacklistFolders` array alphabetically