### PR TITLE
feat: add a command for search css var by value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10298,7 +10298,7 @@
 			}
 		},
 		"packages/css-variables-language-server": {
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.27.2",
@@ -10352,10 +10352,7 @@
 			}
 		},
 		"packages/vscode-css-variables": {
-			"version": "2.6.1",
-			"dependencies": {
-				"css-variables-language-server": "*"
-			},
+			"version": "2.6.3",
 			"devDependencies": {
 				"@types/mocha": "^9.1.1",
 				"@types/node": "^18.7.13",
@@ -10363,6 +10360,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.35.1",
 				"@typescript-eslint/parser": "^5.35.1",
 				"@vscode/test-electron": "^2.1.5",
+				"css-variables-language-server": "*",
 				"eslint": "^8.23.0",
 				"eslint-config-airbnb-typescript": "^17.0.0",
 				"mocha": "^10.0.0",

--- a/packages/css-variables-language-server/src/index.ts
+++ b/packages/css-variables-language-server/src/index.ts
@@ -199,10 +199,6 @@ connection.onCompletion(
         sortText: 'z',
       };
 
-      if (isFunctionCall) {
-        completion.detail = varSymbol.value;
-      }
-
       items.push(completion);
     });
 
@@ -316,6 +312,37 @@ connection.onDefinition((params) => {
   }
 
   return null;
+});
+
+// search a css variable by name or value;
+connection.onRequest('search', async (params): Promise<CompletionItem[]> => {
+  if (!params || typeof params !== 'string') {
+    return [];
+  }
+  const items: CompletionItem[] = [];
+  cssVariableManager.getAll().forEach((variable) => {
+    const varSymbol = variable.symbol;
+    const { name, value } = varSymbol;
+
+    // either of name and value can compare to params
+    if (!name.includes(params) && !value.startsWith(params)) {
+      return;
+    }
+    const insertText = `var(${varSymbol.name})`;
+    const completion: CompletionItem = {
+      label: name,
+      detail: value,
+      documentation: value,
+      insertText,
+      kind: isColor(value)
+        ? CompletionItemKind.Color
+        : CompletionItemKind.Variable,
+      sortText: 'z',
+    };
+    items.push(completion);
+  });
+
+  return items;
 });
 
 // Make the text document manager listen on the connection

--- a/packages/vscode-css-variables/package.json
+++ b/packages/vscode-css-variables/package.json
@@ -32,6 +32,12 @@
 	},
 	"main": "./dist/index.js",
 	"contributes": {
+		"commands": [
+			{
+				"command": "vscode-css-variables.search",
+				"title": "Search for css variable"
+			}
+		],
 		"configuration": {
 			"title": "CSS Variables",
 			"properties": {

--- a/packages/vscode-css-variables/src/commands.ts
+++ b/packages/vscode-css-variables/src/commands.ts
@@ -1,0 +1,18 @@
+import { commands, ExtensionContext, window } from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import search from "./commands/search";
+
+export const commandsMap = {
+  "vscode-css-variables.search": search,
+};
+
+export default function registerCommands(
+  context: ExtensionContext,
+  client: LanguageClient
+) {
+  Object.entries(commandsMap).forEach(([name, command]) => {
+    context.subscriptions.push(
+      commands.registerCommand(name, () => command(client))
+    );
+  });
+}

--- a/packages/vscode-css-variables/src/commands/search.ts
+++ b/packages/vscode-css-variables/src/commands/search.ts
@@ -1,0 +1,37 @@
+import { window } from "vscode";
+import { LanguageClient, CompletionItem } from "vscode-languageclient/node";
+
+export default async function search(client: LanguageClient) {
+  const editor = window.activeTextEditor;
+
+  // 获取当前选择的文本
+  const selectedText = editor?.document.getText(editor.selection)?.trim() ?? "";
+  // 将颜色值或简单文本作为搜索依据
+  const defaultInput = /^(#[0-9A-Fa-f]{3,6})$|^[\w-]+$/.test(selectedText)
+    ? selectedText
+    : "";
+  const input = await window.showInputBox({
+    value: defaultInput,
+    prompt: "Enter the CSS variable name or value to search",
+  });
+  if (!input) {
+    return;
+  }
+
+  // 向 language server 发送请求，获取选项数据
+  const options: CompletionItem[] = await client.sendRequest("search", input);
+
+  // 如果没有查询到数据，就返回
+  if (options.length === 0) {
+    window.showInformationMessage(`No css variable found for '${input}'`);
+    return;
+  }
+
+  // 弹出命令选项，将选项数据提供给用户选择
+  const selectedOption = await window.showQuickPick(options);
+  if (selectedOption && editor) {
+    editor.edit((edit) => {
+      edit.replace(editor.selection, selectedOption.insertText);
+    });
+  }
+}

--- a/packages/vscode-css-variables/src/index.ts
+++ b/packages/vscode-css-variables/src/index.ts
@@ -12,6 +12,7 @@ import {
   ServerOptions,
   TransportKind,
 } from 'vscode-languageclient/node';
+import registerCommands from './commands';
 
 let client: LanguageClient;
 
@@ -76,6 +77,8 @@ export function activate(context: ExtensionContext) {
 
   // Start the client. This will also launch the server
   client.start();
+
+  registerCommands(context, client);
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
Hi there!

I would like to suggest adding a new feature to the CSS Variable Autocomplete extension in VSCode. The feature would be a new command that allows users to insert a CSS variable by searching for a color or other type of value when they don't know the name of the variable.

I believe this feature would greatly improve the usability of the extension and make it easier for users to work with CSS variables.

Please let me know if you have any questions or if there is anything else I can do to help.

hear are some screen shots shows this.

<img width="667" alt="image" src="https://user-images.githubusercontent.com/7811794/221926899-1071a1ed-7101-491b-88ff-0d5687502b1e.png">
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/7811794/221927090-52b899d7-e6f8-492c-9388-ae16b98c98d3.png">
<img width="885" alt="image" src="https://user-images.githubusercontent.com/7811794/221927190-aa0298ca-bd6d-4ff8-9da3-54a718b4f96f.png">
<img width="909" alt="image" src="https://user-images.githubusercontent.com/7811794/221927254-b0d6490b-f916-4c44-9022-2e434f7aa320.png">

Thank you for your consideration!


