### PR TITLE
Added setting to configure languages the extension should provide suggestions

### DIFF
--- a/.changeset/rude-students-mate.md
+++ b/.changeset/rude-students-mate.md
@@ -1,0 +1,5 @@
+---
+"vscode-css-variables": patch
+---
+
+Added setting to configure languages the extension should provide suggestions

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **[Install via the Visual Studio Code Marketplace →](https://marketplace.visualstudio.com/items?itemName=vunguyentuan.vscode-css-variables)**
 
-By default the extension only scan files with this glob patterns: 
+By default the extension only scan files with this glob patterns:
 
 ```json
 [
@@ -26,12 +26,33 @@ And ignore files in these folders:
 	"**/.hg",
 	"**/CVS",
 	"**/.DS_Store",
-	"**/.git",
 	"**/node_modules",
 	"**/bower_components",
 	"**/tmp",
 	"**/dist",
 	"**/tests"
+]
+```
+
+And provides suggestions to files for the following languages
+
+```json
+[
+	"astro",
+	"svelte",
+	"vue",
+	"vue-html",
+	"vue-postcss",
+	"scss",
+	"postcss",
+	"less",
+	"css",
+	"html",
+	"javascript",
+	"javascriptreact",
+	"typescript",
+	"typescriptreact",
+	"source.css.styled"
 ]
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10298,7 +10298,7 @@
 			}
 		},
 		"packages/css-variables-language-server": {
-			"version": "2.6.1",
+			"version": "2.6.4",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.27.2",
@@ -10352,10 +10352,7 @@
 			}
 		},
 		"packages/vscode-css-variables": {
-			"version": "2.6.1",
-			"dependencies": {
-				"css-variables-language-server": "*"
-			},
+			"version": "2.6.3",
 			"devDependencies": {
 				"@types/mocha": "^9.1.1",
 				"@types/node": "^18.7.13",
@@ -10363,6 +10360,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.35.1",
 				"@typescript-eslint/parser": "^5.35.1",
 				"@vscode/test-electron": "^2.1.5",
+				"css-variables-language-server": "*",
 				"eslint": "^8.23.0",
 				"eslint-config-airbnb-typescript": "^17.0.0",
 				"mocha": "^10.0.0",

--- a/packages/vscode-css-variables/package.json
+++ b/packages/vscode-css-variables/package.json
@@ -61,6 +61,28 @@
 						]
 					}
 				},
+				"cssVariables.languages": {
+					"type": "array",
+					"markdownDescription": "Configure the languages for which the extension should be activated. Read more about language identifiers [here](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers).",
+					"default": [
+						"astro",
+						"svelte",
+						"vue",
+						"vue-html",
+						"vue-postcss",
+						"scss",
+						"postcss",
+						"less",
+						"css",
+						"html",
+						"javascript",
+						"javascriptreact",
+						"typescript",
+						"typescriptreact",
+						"source.css.styled"
+					],
+					"scope": 3
+				},
 				"cssVariables.blacklistFolders": {
 					"type": "array",
 					"markdownDescription": "Configure glob patterns for excluding files and folders. The extension will not scan variables in these files and folders. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
@@ -70,7 +92,6 @@
 						"**/.hg",
 						"**/CVS",
 						"**/.DS_Store",
-						"**/.git",
 						"**/node_modules",
 						"**/bower_components",
 						"**/tmp",

--- a/packages/vscode-css-variables/src/index.ts
+++ b/packages/vscode-css-variables/src/index.ts
@@ -34,25 +34,28 @@ export function activate(context: ExtensionContext) {
     },
   };
 
+	const settings = workspace.getConfiguration('cssVariables');
+	const languages = settings.get('languages', [
+		'astro',
+		'svelte',
+		'vue',
+		'vue-html',
+		'vue-postcss',
+		'scss',
+		'postcss',
+		'less',
+		'css',
+		'html',
+		'javascript',
+		'javascriptreact',
+		'typescript',
+		'typescriptreact',
+		'source.css.styled',
+	]);
+
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-      'onLanguage:astro',
-      'onLanguage:svelte',
-      'onLanguage:vue',
-      'onLanguage:vue-html',
-      'onLanguage:vue-postcss',
-      'onLanguage:scss',
-      'onLanguage:postcss',
-      'onLanguage:less',
-      'onLanguage:css',
-      'onLanguage:html',
-      'onLanguage:javascript',
-      'onLanguage:javascriptreact',
-      'onLanguage:typescript',
-      'onLanguage:typescriptreact',
-      'onLanguage:source.css.styled',
-    ].map((event) => ({
+    documentSelector: languages.map((event) => ({
       scheme: 'file',
       language: event.split(':')[1],
     })),


### PR DESCRIPTION
Closes #58

I understand the extension wants to cover as many languages as possible, but ideally, the user chooses which languages they want suggestions. In my case I only want it is css and less, nowhere else