### PR TITLE
Add executable for language server

### DIFF
--- a/.changeset/loud-lizards-tan.md
+++ b/.changeset/loud-lizards-tan.md
@@ -1,0 +1,10 @@
+---
+"css-variables-language-server": minor
+---
+
+Add executable for language server to run from the commandline.
+
+```sh
+$ npm install -g css-variables-language-server
+$ css-variables-language-server --stdio
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10314,6 +10314,9 @@
 				"vscode-languageserver-textdocument": "^1.0.1",
 				"vscode-uri": "^3.0.3"
 			},
+			"bin": {
+				"css-variables-language-server": "bin/index.mjs"
+			},
 			"devDependencies": {
 				"@types/jest": "^28.1.8",
 				"@types/less": "^3.0.3",
@@ -10352,7 +10355,7 @@
 			}
 		},
 		"packages/vscode-css-variables": {
-			"version": "2.6.3",
+			"version": "2.6.5",
 			"devDependencies": {
 				"@types/mocha": "^9.1.1",
 				"@types/node": "^18.7.13",

--- a/packages/css-variables-language-server/.eslintrc.js
+++ b/packages/css-variables-language-server/.eslintrc.js
@@ -1,20 +1,17 @@
 /**@type {import('eslint').Linter.Config} */
 // eslint-disable-next-line no-undef
 module.exports = {
-	root: true,
-	parser: '@typescript-eslint/parser',
-	plugins: [
-		'@typescript-eslint',
-	],
-	extends: [
-		'eslint:recommended',
-		'plugin:@typescript-eslint/recommended',
-	],
-	rules: {
-		'semi': [2, "always"],
-		'@typescript-eslint/no-unused-vars': 0,
-		'@typescript-eslint/no-explicit-any': 0,
-		'@typescript-eslint/explicit-module-boundary-types': 0,
-		'@typescript-eslint/no-non-null-assertion': 0,
-	}
+  root: true,
+  env: { node: true },
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  rules: {
+    semi: [2, "always"],
+    "@typescript-eslint/no-unused-vars": 0,
+    "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/explicit-module-boundary-types": 0,
+    "@typescript-eslint/no-non-null-assertion": 0
+  }
 };
+

--- a/packages/css-variables-language-server/bin/index.js
+++ b/packages/css-variables-language-server/bin/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("../dist/index.js");

--- a/packages/css-variables-language-server/package.json
+++ b/packages/css-variables-language-server/package.json
@@ -1,47 +1,50 @@
 {
-	"name": "css-variables-language-server",
-	"description": "CSS Variables Language Server in node.",
-	"version": "2.6.4",
-	"author": "Vu Nguyen",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/vunguyentuan/vscode-css-variables.git"
-	},
-	"main": "dist/index.js",
-	"dependencies": {
-		"axios": "^0.27.2",
-		"culori": "0.20.1",
-		"fast-glob": "^3.2.7",
-		"less": "^4.1.3",
-		"line-column": "^1.0.2",
-		"postcss": "^8.4.16",
-		"postcss-less": "^6.0.0",
-		"postcss-scss": "^4.0.4",
-		"sass": "^1.54.7",
-		"vscode-languageserver": "^7.0.0",
-		"vscode-languageserver-textdocument": "^1.0.1",
-		"vscode-uri": "^3.0.3"
-	},
-	"scripts": {
-		"test": "jest",
-		"build": "tsup src/index.ts --format esm,cjs",
-		"dev": "tsup src/index.ts --format esm,cjs --watch",
-		"clean": "rm -rf dist",
-		"lint": "eslint ./src --ext .ts,.tsx --fix"
-	},
-	"devDependencies": {
-		"@types/jest": "^28.1.8",
-		"@types/less": "^3.0.3",
-		"@types/postcss-less": "^4.0.2",
-		"@typescript-eslint/eslint-plugin": "^5.35.1",
-		"@typescript-eslint/parser": "^5.35.1",
-		"eslint": "^8.23.0",
-		"eslint-config-airbnb-typescript": "^17.0.0",
-		"jest": "^28.0.0",
-		"jest-environment-node-single-context": "^28.1.0",
-		"ts-jest": "^28.0.8",
-		"tsup": "^6.2.3",
-		"typescript": "^4.8.2"
-	}
+  "name": "css-variables-language-server",
+  "description": "CSS Variables Language Server in node.",
+  "version": "2.6.4",
+  "author": "Vu Nguyen",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vunguyentuan/vscode-css-variables.git"
+  },
+  "main": "dist/index.js",
+  "bin": {
+    "css-variables-language-server": "bin/index.js"
+  },
+  "dependencies": {
+    "axios": "^0.27.2",
+    "culori": "0.20.1",
+    "fast-glob": "^3.2.7",
+    "less": "^4.1.3",
+    "line-column": "^1.0.2",
+    "postcss": "^8.4.16",
+    "postcss-less": "^6.0.0",
+    "postcss-scss": "^4.0.4",
+    "sass": "^1.54.7",
+    "vscode-languageserver": "^7.0.0",
+    "vscode-languageserver-textdocument": "^1.0.1",
+    "vscode-uri": "^3.0.3"
+  },
+  "scripts": {
+    "test": "jest",
+    "build": "tsup src/index.ts --format esm,cjs",
+    "dev": "tsup src/index.ts --format esm,cjs --watch",
+    "clean": "rm -rf dist",
+    "lint": "eslint ./src --ext .ts,.tsx --fix"
+  },
+  "devDependencies": {
+    "@types/jest": "^28.1.8",
+    "@types/less": "^3.0.3",
+    "@types/postcss-less": "^4.0.2",
+    "@typescript-eslint/eslint-plugin": "^5.35.1",
+    "@typescript-eslint/parser": "^5.35.1",
+    "eslint": "^8.23.0",
+    "eslint-config-airbnb-typescript": "^17.0.0",
+    "jest": "^28.0.0",
+    "jest-environment-node-single-context": "^28.1.0",
+    "ts-jest": "^28.0.8",
+    "tsup": "^6.2.3",
+    "typescript": "^4.8.2"
+  }
 }


### PR DESCRIPTION
I'm interested in using the language server in Neovim, but it's less than ideal to implement without an executable to use. [(Here are a bunch of examples.)](https://github.com/neovim/nvim-lspconfig/tree/master/lua/lspconfig/server_configurations) This simply adds a `bin` script so that the language server can be run as so:

```bash
$ css-variables-language-server --stdio
```