### PR TITLE
feat: add at-custom-media handling via enableCustomMedia

### DIFF
--- a/.changeset/add-custom-media-support.md
+++ b/.changeset/add-custom-media-support.md
@@ -1,0 +1,15 @@
+---
+"css-variables-language-server": minor
+"vscode-css-variables": minor
+---
+
+Add support for `@custom-media` rules behind new
+`cssVariables.enableCustomMedia` configuration flag.
+
+- Adds completion, hover, and go-to-definition when enabled
+
+```json
+{
+  "cssVariables.enableCustomMedia": true
+}
+```

--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ And provides suggestions to files for the following languages
 ]
 ```
 
+
+### Custom Media Support
+
+You can enable indexing of `@custom-media` rules. When enabled the server will provide
+completion, hover information and go‑to‑definition for custom media names:
+
+*.vscode/settings.json*
+```json
+{
+  "cssVariables.enableCustomMedia": true
+}
+```
+
 ## Features
 ### Autocomplete & Color Preview
 

--- a/packages/css-variables-language-server/src/tests/fixtures/custom-media/main.css
+++ b/packages/css-variables-language-server/src/tests/fixtures/custom-media/main.css
@@ -1,0 +1,6 @@
+@custom-media --small-viewport (max-width: 30em);
+@custom-media --dark-theme (prefers-color-scheme: dark);
+
+:root {
+  --foo: bar;
+}

--- a/packages/css-variables-language-server/src/tests/unit-tests/CSSVariableManager.test.ts
+++ b/packages/css-variables-language-server/src/tests/unit-tests/CSSVariableManager.test.ts
@@ -1,4 +1,4 @@
-import CSSVariableManager, { CSSVariable } from '../../CSSVariableManager';
+import CSSVariableManager, { CSSVariable, defaultSettings } from '../../CSSVariableManager';
 import * as path from 'path';
 
 async function runTest(
@@ -208,5 +208,18 @@ describe('CSS Variable Manager', () => {
     expect(allVars.get('--child-nested').symbol.value).toEqual('var(--color-red-alias-3)');
     expect(allVars.get('--child-nested').color).toBeDefined();
     expect(allVars.get('--child-nested').color).toEqual(allVars.get('--color-red').color);
+  });
+
+  test('can parse @custom-media definitions when enabled', async () => {
+    const cssManager = new CSSVariableManager();
+    const settings = { ...defaultSettings, enableCustomMedia: true };
+
+    await cssManager.parseAndSyncVariables([
+      path.join(__dirname, '../fixtures/custom-media'),
+    ], settings as any);
+
+    const allMedia = cssManager.getAllCustomMedia();
+    expect(allMedia.get('--small-viewport').params).toEqual('(max-width: 30em)');
+    expect(allMedia.get('--dark-theme').params).toEqual('(prefers-color-scheme: dark)');
   });
 });

--- a/packages/vscode-css-variables/package.json
+++ b/packages/vscode-css-variables/package.json
@@ -127,6 +127,11 @@
 					],
 					"default": "off",
 					"description": "Traces the communication between VS Code and the language server."
+				},
+				"cssVariables.enableCustomMedia": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enable indexing and completion for @custom-media rules."
 				}
 			}
 		}

--- a/packages/vscode-css-variables/src/test/completion.test.ts
+++ b/packages/vscode-css-variables/src/test/completion.test.ts
@@ -14,7 +14,9 @@ import {
 suite('Should do completion', () => {
   const docUri = getDocUri('test.css');
 
-  test.only('Completes in css file', async () => {
+  test('Completes in css file', async () => {
+    // ensure custom media feature is off for this first assertion
+    await vscode.workspace.getConfiguration().update('cssVariables.enableCustomMedia', false, vscode.ConfigurationTarget.Workspace);
     await testCompletion(docUri, 'color: -^', {
       items: [
         {
@@ -28,12 +30,97 @@ suite('Should do completion', () => {
       ],
     });
   });
+
+  test('Completes custom media when enabled', async () => {
+    await vscode.workspace.getConfiguration().update('cssVariables.enableCustomMedia', true, vscode.ConfigurationTarget.Workspace);
+    await testCompletion(docUri, '@media (--^', {
+      items: [
+        {
+          label: '--small-viewport',
+          kind: vscode.CompletionItemKind.Variable,
+        },
+      ],
+      notItems: [
+        {
+          label: '--chakra-ring-offset-width',
+        },
+        {
+          label: '--chakra-ring-color',
+        },
+      ],
+    });
+  });
+
+  test('Completes custom media even when closing parenthesis already present', async () => {
+    await vscode.workspace.getConfiguration().update('cssVariables.enableCustomMedia', true, vscode.ConfigurationTarget.Workspace);
+    await testCompletion(docUri, '@media (--)^', {
+      items: [
+        {
+          label: '--small-viewport',
+          kind: vscode.CompletionItemKind.Variable,
+        },
+      ],
+      notItems: [
+        {
+          label: '--chakra-ring-offset-width',
+        },
+        {
+          label: '--chakra-ring-color',
+        },
+      ],
+    });
+  });
+
+  test('does not suggest custom media outside @media', async () => {
+    await vscode.workspace.getConfiguration().update('cssVariables.enableCustomMedia', true, vscode.ConfigurationTarget.Workspace);
+    await testCompletion(docUri, 'color: -^', {
+      items: [
+        // the previously expected variable entries, but no --small-viewport
+        {
+          label: '--chakra-ring-offset-width',
+          kind: vscode.CompletionItemKind.Variable,
+        },
+        {
+          label: '--chakra-ring-color',
+          kind: vscode.CompletionItemKind.Color,
+        },
+      ],
+      // ensure our custom media item is absent
+      notItems: [
+        {
+          label: '--small-viewport',
+        },
+      ],
+    });
+  });
+
+  test('Hover/definition for custom media', async () => {
+    await vscode.workspace.getConfiguration().update('cssVariables.enableCustomMedia', true, vscode.ConfigurationTarget.Workspace);
+    await activate(docUri);
+
+    // hover
+    let pos = positionOf('@media (--small-viewport^');
+    let hover = await vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', docUri, pos);
+    assert.ok(hover && hover.length > 0);
+    assert.ok(hover[0].contents.some((c) => typeof c === 'string' ? c.includes('(max-width: 30em)') : false));
+
+    // definition
+    pos = positionOf('@media (--small-viewport^');
+    const defs = await vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', docUri, pos);
+    assert.ok(defs && defs.length > 0);
+    assert.strictEqual(defs[0].uri.fsPath.endsWith('test.css'), true);
+  });
 });
+
+interface Expectation {
+  items: Array<{ label: string; kind?: vscode.CompletionItemKind }>;
+  notItems?: Array<{ label: string }>;
+}
 
 async function testCompletion(
   docUri: vscode.Uri,
   searchText: string,
-  expectedCompletionList: vscode.CompletionList,
+  expectedCompletionList: vscode.CompletionList & Expectation,
 ) {
   await activate(docUri);
 
@@ -56,8 +143,20 @@ async function testCompletion(
       return false;
     });
 
-    assert.ok(actualItem);
+    assert.ok(actualItem, `Expected completion ${expectedItem.label} was not present`);
     assert.strictEqual(actualItem.label, expectedItem.label);
     assert.strictEqual(actualItem.kind, expectedItem.kind);
   });
+
+  if (expectedCompletionList.notItems) {
+    expectedCompletionList.notItems.forEach((not) => {
+      const found = actualCompletionList.items.find((item) => {
+        if (typeof item.label === 'string') {
+          return item.label === not.label;
+        }
+        return false;
+      });
+      assert.strictEqual(found, undefined, `Did not expect completion ${not.label}`);
+    });
+  }
 }

--- a/packages/vscode-css-variables/testFixture/test.css
+++ b/packages/vscode-css-variables/testFixture/test.css
@@ -1,3 +1,5 @@
+@custom-media --small-viewport (max-width: 30em);
+
 body {
 	background-color: -- 
 }


### PR DESCRIPTION
Resolves #103.

This adds a new setting `"cssVariables.enableCustomMedia"` (default off) for IDE tooling around the `@custom-media` CSS rule.
I'm mostly adding this so I do not have to look up open-props custom-media rule names and because I wanted to add to this ecosystem a bit :)

In the end I had to do much more than expected but I hope it's still comprehensible enough.
