### PR TITLE
Fix order of variables with numeric components

### DIFF
--- a/.changeset/few-gifts-smoke.md
+++ b/.changeset/few-gifts-smoke.md
@@ -1,0 +1,5 @@
+---
+'css-variables-language-server': minor
+---
+
+Fix sorting of variables with numeric components

--- a/packages/css-variables-language-server/src/index.ts
+++ b/packages/css-variables-language-server/src/index.ts
@@ -196,7 +196,7 @@ connection.onCompletion(
       const insertText = isFunctionCall
         ? varSymbol.name
         : `var(${varSymbol.name})`;
-      
+
       const start = doc.positionAt(wordInfo.left + 1);
       const end = doc.positionAt(wordInfo.right);
       const range = { start, end };
@@ -210,7 +210,7 @@ connection.onCompletion(
         kind: isColor(varSymbol.value)
           ? CompletionItemKind.Color
           : CompletionItemKind.Variable,
-        sortText: 'z',
+        sortText: varSymbol.name.replace(/(.*?)(\d+)$/, (_, label, num) => label + num.padStart(4, '0'))
       };
 
       if (isColor(varSymbol.value)) {

--- a/packages/vscode-css-variables/src/test/completion.test.ts
+++ b/packages/vscode-css-variables/src/test/completion.test.ts
@@ -15,17 +15,23 @@ suite('Should do completion', () => {
   const docUri = getDocUri('test.css');
 
   test.only('Completes in css file', async () => {
-    await testCompletion(docUri, 'color: -^', {
-      items: [
-        {
-          label: '--chakra-ring-offset-width',
-          kind: vscode.CompletionItemKind.Variable,
-        },
-        {
-          label: '--chakra-ring-color',
-          kind: vscode.CompletionItemKind.Color,
-        },
-      ],
+    await testCompletion(docUri, 'color: -^', (completionList) => {
+      assertItem(completionList, {
+        label: '--chakra-ring-offset-width',
+        kind: vscode.CompletionItemKind.Variable,
+      });
+
+      assertItem(completionList, {
+        label: '--chakra-ring-color',
+        kind: vscode.CompletionItemKind.Color,
+      });
+
+      assertOrder(completionList, [
+        '--size-1',
+        '--size-2',
+        '--size-10'
+      ]);
+
     });
   });
 });
@@ -33,7 +39,7 @@ suite('Should do completion', () => {
 async function testCompletion(
   docUri: vscode.Uri,
   searchText: string,
-  expectedCompletionList: vscode.CompletionList,
+  then: (actualCompletionList: vscode.CompletionList) => void,
 ) {
   await activate(docUri);
 
@@ -47,17 +53,30 @@ async function testCompletion(
     toPosition,
   );
 
-  expectedCompletionList.items.forEach((expectedItem) => {
-    const actualItem = actualCompletionList.items.find((item) => {
-      if (typeof item.label === 'string') {
-        return item.label === expectedItem.label;
-      }
+  then(actualCompletionList);
+}
 
-      return false;
-    });
-
-    assert.ok(actualItem);
-    assert.strictEqual(actualItem.label, expectedItem.label);
-    assert.strictEqual(actualItem.kind, expectedItem.kind);
+function assertItem(actualCompletionList: vscode.CompletionList, expectedItem) {
+  const actualItem = actualCompletionList.items.find((item) => {
+    if (typeof item.label === 'string') {
+      return item.label === expectedItem.label;
+    }
   });
+
+  assert.ok(actualItem);
+  assert.strictEqual(actualItem.label, expectedItem.label);
+  assert.strictEqual(actualItem.kind, expectedItem.kind);
+}
+
+function assertOrder(actualCompletionList: vscode.CompletionList, expectedItems) {
+  const expectedItemsSet = new Set(expectedItems);
+
+  const actualOrder = actualCompletionList.items.reduce((acc, item) => {
+    if (typeof item.label === 'string' && expectedItemsSet.has(item.label)) {
+      acc.push(item.label);
+    }
+    return acc;
+  }, []);
+
+  assert.deepStrictEqual(actualOrder, expectedItems);
 }

--- a/packages/vscode-css-variables/testFixture/variable.css
+++ b/packages/vscode-css-variables/testFixture/variable.css
@@ -3,4 +3,7 @@
   --chakra-ring-color: rgba(66, 153, 225, 0.6);
   --chakra-space-x-reverse: 0;
   --chakra-fontSizes-md: 1rem;
+  --size-1: 2px;
+  --size-2: 4px;
+  --size-10: 10px;
 }


### PR DESCRIPTION
Fixes #24 

I don't think a configuration option for this is necessary, this seems like sane / expected behaviour out of the box

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td><img width="676" height="293" alt="before" src="https://github.com/user-attachments/assets/7a1bff98-6faa-4851-a732-ddd1ab7c6fc8" />
 <td><img width="722" height="316" alt="after" src="https://github.com/user-attachments/assets/ff2e1477-204f-4fc7-8292-7a064526c18a" />
</table>