### PR TITLE
fix: handle culori.parse throwing on complex CSS values

### DIFF
--- a/.changeset/fix-iscolor-culori-throws.md
+++ b/.changeset/fix-iscolor-culori-throws.md
@@ -1,0 +1,5 @@
+---
+"css-variables-language-server": patch
+---
+
+Fix completion list being truncated when a CSS variable value causes `culori.parse` to throw. Variables with complex `background` shorthand values (e.g. containing `linear-gradient()`) triggered an unhandled exception in `isColor`, aborting the completion loop early and dropping all subsequent variables from suggestions.

--- a/packages/css-variables-language-server/src/utils/isColor.ts
+++ b/packages/css-variables-language-server/src/utils/isColor.ts
@@ -1,9 +1,11 @@
 import * as culori from 'culori';
 
 const isColor = (str: string) => {
-  const colorTemp = culori.parse(str);
-
-  return !!colorTemp;
+  try {
+    return !!culori.parse(str);
+  } catch {
+    return false;
+  }
 };
 
 export default isColor;


### PR DESCRIPTION
## Summary

Fixes #127.

`isColor` calls `culori.parse(str)` without a try/catch. `culori.parse` throws on some valid CSS values — specifically `background` shorthands containing `linear-gradient()`, e.g.:

```css
--sapField_ReadOnly_BackgroundStyle: 0 100% / 0.375rem .0625rem repeat-x linear-gradient(90deg, ...) border-box;
```

The thrown error:

```
TypeError: Cannot read properties of undefined (reading 'type')
```

The unhandled exception propagates out of the `.forEach` loop in the completion handler (`index.ts:194`), aborting iteration early. All variables defined after the throwing variable are silently dropped from the completion list.

**Fix**: wrap `culori.parse` in `isColor` with try/catch, returning `false` on error.

## Changes

- `packages/css-variables-language-server/src/utils/isColor.ts`: wrap `culori.parse` call in try/catch